### PR TITLE
Fix private property bug in MixedNodeInputElement

### DIFF
--- a/demo/src/components/MixedNodeInputElement.js
+++ b/demo/src/components/MixedNodeInputElement.js
@@ -33,7 +33,7 @@ const MixedNodeElement = ({ nodeData = {}, triggerNodeToggle, foreignObjectProps
           </select>
           {nodeData.children && (
             <button style={{ textAlign: 'center' }} onClick={triggerNodeToggle}>
-              {nodeData.__rd3t.collapsed ? '⬅️ ➡️ Expand' : '➡️ ⬅️ Collapse'}
+              {nodeData.__rd3dag.collapsed ? '⬅️ ➡️ Expand' : '➡️ ⬅️ Collapse'}
             </button>
           )}
         </div>


### PR DESCRIPTION
Hello @forivall.

In MixedNodeInputElement.js, nodeData in MixedNodeElement has private property __rd3dag, 
but was looking for the collapsed property on __rd3t, which was undefined. If you try to render 
customNodeFnMapping['input'].fn in App.state's renderCustomNodeElement property the 
browser will throw this error. This code change fixes the issue and it now renders properly. 

Thanks for the awesome library!